### PR TITLE
Add mode-specific configurations

### DIFF
--- a/configs/process.yaml
+++ b/configs/process.yaml
@@ -1,0 +1,46 @@
+mode: process
+experiment_name: inference_run
+seed: 42
+output_dir: outputs
+
+model:
+  backbone: resnet50
+  num_classes: 21
+  checkpoint_path: models/checkpoint.pth
+  output_stride: 16
+
+data:
+  data_dir: data/test
+  bands: [red, green, blue, nir]
+  image_size: [512, 512]
+  normalize: true
+  stats:
+    mean: [0.485, 0.456, 0.406]  # ImageNet stats for RGB
+    std: [0.229, 0.224, 0.225]   # Custom stats for MS bands will be loaded from checkpoint
+
+spectral:
+  indices: [ndvi, evi]
+  use_as_features: true
+  band_attention: true
+  fusion_type: adaptive
+
+processing:
+  batch_size: 1
+  device: cuda
+  half_precision: true
+  output_format: geotiff
+  preserve_metadata: true
+  confidence_threshold: 0.5
+  tile_size: [1024, 1024]  # For processing large images
+  overlap: 64  # Overlap between tiles to avoid boundary artifacts
+  ensemble:
+    enabled: false
+    flip_augmentation: true
+    scale_augmentation: false
+  post_processing:
+    apply_crf: false  # Conditional Random Field
+    median_filter: 0  # Kernel size for median filter, 0 to disable
+  visualization:
+    save_overlay: true
+    colormap: cityscapes
+    alpha: 0.5

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,0 +1,48 @@
+mode: train
+experiment_name: multispectral_segmentation
+seed: 42
+output_dir: outputs
+
+model:
+  backbone: resnet50
+  output_stride: 16
+  num_classes: 21
+  pretrained: true
+
+data:
+  data_dir: data/dataset
+  train_split: train
+  val_split: val
+  batch_size: 16
+  bands: [red, green, blue, nir]
+  image_size: [512, 512]
+  num_workers: 4
+
+spectral:
+  indices: [ndvi, evi]
+  use_as_features: true
+  band_attention: true
+  fusion_type: adaptive
+
+training:
+  epochs: 100
+  learning_rate: 0.001
+  lr_scheduler: cosine
+  warmup_epochs: 5
+  weight_decay: 0.0001
+  mixed_precision: true
+  grad_clip: 1.0
+  early_stopping:
+    patience: 10
+    min_delta: 0.001
+  optimizer:
+    name: adamw
+    beta1: 0.9
+    beta2: 0.999
+  loss:
+    name: cross_entropy
+    class_weights: null  # Set to list of weights for class imbalance
+  metrics:
+    - mean_iou
+    - pixel_accuracy
+    - f1_score


### PR DESCRIPTION
This PR adds mode-specific configurations for training and processing:

- Add train.yaml and process.yaml configuration files
- Update README.md with mode-specific usage examples
- Update config.py with mode validation
- Improve file structure documentation

The changes separate the system into two distinct modes:
1. Training Mode: For model training and evaluation
2. Processing Mode: For inference on new data

Each mode has its own configuration file with appropriate settings.